### PR TITLE
Stage 2: Extract Pydantic Models

### DIFF
--- a/src/slack_mcp/README.md
+++ b/src/slack_mcp/README.md
@@ -46,6 +46,26 @@ slack_mcp/
 - Maintained all original functionality without breaking changes
 - Added proper __all__ exports in __init__.py files
 
+## Stage 2: Extract Pydantic Models (Completed)
+
+### What was done:
+1. Created `models/schemas.py` with all Pydantic models:
+   - **SlackTokenValidation**: Token validation model
+   - **ChannelInfo**: Channel information request model
+   - **MessageInfo**: Message sending request model
+   - **UserInfo**: User information request model  
+   - **FileUploadInfo**: File upload request model
+
+2. Updated `models/__init__.py` to export all models
+3. Removed model definitions from `slack_mcp_server.py`
+4. Updated imports to use models from the new location
+
+### Verification:
+- All models maintain their exact definitions
+- Field descriptions preserved for MCP tool generation
+- Pydantic validation still working correctly
+- No functional changes to tool behavior
+
 ## Next Steps
 
 ### Stage 2: Extract Pydantic Models

--- a/src/slack_mcp/models/__init__.py
+++ b/src/slack_mcp/models/__init__.py
@@ -1,0 +1,17 @@
+"""Pydantic models for Slack MCP Server."""
+
+from .schemas import (
+    SlackTokenValidation,
+    ChannelInfo,
+    MessageInfo,
+    UserInfo,
+    FileUploadInfo,
+)
+
+__all__ = [
+    "SlackTokenValidation",
+    "ChannelInfo",
+    "MessageInfo",
+    "UserInfo",
+    "FileUploadInfo",
+]

--- a/src/slack_mcp/models/schemas.py
+++ b/src/slack_mcp/models/schemas.py
@@ -1,0 +1,40 @@
+"""
+Pydantic models for Slack MCP Server.
+Defines request/response validation schemas for all tools.
+"""
+from typing import Any, Dict, List, Optional
+from pydantic import BaseModel, Field
+
+
+class SlackTokenValidation(BaseModel):
+    """Model for Slack token validation."""
+    token: str = Field(description="Slack bot token (xoxb-*) or user token (xoxp-*)")
+
+
+class ChannelInfo(BaseModel):
+    """Model for channel information requests."""
+    channel: str = Field(description="Channel ID or name (e.g., 'C1234567890' or '#general')")
+
+
+class MessageInfo(BaseModel):
+    """Model for message sending requests."""
+    channel: str = Field(description="Channel ID or name")
+    text: str = Field(description="Message text to send")
+    thread_ts: Optional[str] = Field(None, description="Timestamp of parent message to reply in thread")
+    blocks: Optional[List[Dict[str, Any]]] = Field(None, description="Slack blocks for rich formatting")
+    attachments: Optional[List[Dict[str, Any]]] = Field(None, description="Message attachments")
+
+
+class UserInfo(BaseModel):
+    """Model for user information requests."""
+    user: str = Field(description="User ID or email address")
+
+
+class FileUploadInfo(BaseModel):
+    """Model for file upload requests."""
+    channels: str = Field(description="Comma-separated list of channel IDs or names")
+    content: Optional[str] = Field(None, description="File content as text")
+    filename: Optional[str] = Field(None, description="Name of the file")
+    filetype: Optional[str] = Field(None, description="File type (e.g., 'text', 'json', 'csv')")
+    title: Optional[str] = Field(None, description="Title of the file")
+    initial_comment: Optional[str] = Field(None, description="Initial comment for the file")

--- a/src/slack_mcp_server.py
+++ b/src/slack_mcp_server.py
@@ -12,12 +12,11 @@ from slack_sdk import WebClient
 from slack_sdk.web.async_client import AsyncWebClient
 from slack_sdk.errors import SlackApiError
 import httpx
-from pydantic import BaseModel, Field
 import time
 import json
 from datetime import datetime
 
-# Import utilities from the new package structure
+# Import utilities and models from the new package structure
 try:
     # Try absolute import first (when installed as package)
     from slack_mcp.utils import (
@@ -34,6 +33,13 @@ try:
         MIN_API_INTERVAL,
         rate_limit_check,
         make_slack_request,
+    )
+    from slack_mcp.models import (
+        SlackTokenValidation,
+        ChannelInfo,
+        MessageInfo,
+        UserInfo,
+        FileUploadInfo,
     )
 except ImportError:
     # Fall back to relative import (when running directly)
@@ -55,6 +61,13 @@ except ImportError:
         rate_limit_check,
         make_slack_request,
     )
+    from slack_mcp.models import (
+        SlackTokenValidation,
+        ChannelInfo,
+        MessageInfo,
+        UserInfo,
+        FileUploadInfo,
+    )
 
 # Configure logging
 logging.basicConfig(level=logging.INFO)
@@ -62,31 +75,6 @@ logger = logging.getLogger(__name__)
 
 # Initialize FastMCP server
 mcp = FastMCP("slack", description="A comprehensive MCP server for Slack API operations")
-
-# Pydantic models for request/response validation
-class SlackTokenValidation(BaseModel):
-    token: str = Field(description="Slack bot token (xoxb-*) or user token (xoxp-*)")
-
-class ChannelInfo(BaseModel):
-    channel: str = Field(description="Channel ID or name (e.g., 'C1234567890' or '#general')")
-
-class MessageInfo(BaseModel):
-    channel: str = Field(description="Channel ID or name")
-    text: str = Field(description="Message text to send")
-    thread_ts: Optional[str] = Field(None, description="Timestamp of parent message to reply in thread")
-    blocks: Optional[List[Dict[str, Any]]] = Field(None, description="Slack blocks for rich formatting")
-    attachments: Optional[List[Dict[str, Any]]] = Field(None, description="Message attachments")
-
-class UserInfo(BaseModel):
-    user: str = Field(description="User ID or email address")
-
-class FileUploadInfo(BaseModel):
-    channels: str = Field(description="Comma-separated list of channel IDs or names")
-    content: Optional[str] = Field(None, description="File content as text")
-    filename: Optional[str] = Field(None, description="Name of the file")
-    filetype: Optional[str] = Field(None, description="File type (e.g., 'text', 'json', 'csv')")
-    title: Optional[str] = Field(None, description="Title of the file")
-    initial_comment: Optional[str] = Field(None, description="Initial comment for the file")
 
 
 @mcp.tool("set_slack_token")


### PR DESCRIPTION
## Summary

This PR implements Stage 2 of the Slack MCP Server refactoring effort (#20), focusing on extracting all Pydantic models to a dedicated module.

## Changes

### Models Extracted
Moved the following 5 Pydantic models from `slack_mcp_server.py` to `models/schemas.py`:
- **SlackTokenValidation**: Token validation model
- **ChannelInfo**: Channel information request model  
- **MessageInfo**: Message sending request model (with optional threading/blocks)
- **UserInfo**: User information request model
- **FileUploadInfo**: File upload request model (with multiple optional fields)

### File Changes
1. **Created `models/schemas.py`**:
   - Contains all 5 Pydantic models with their exact definitions
   - Preserves all field descriptions for MCP tool generation
   - Added docstrings for each model class

2. **Updated `models/__init__.py`**:
   - Imports all models from schemas.py
   - Exports them via `__all__` for clean API

3. **Updated `slack_mcp_server.py`**:
   - Added model imports to both try/except import blocks
   - Removed all original model definitions
   - No changes to tool implementations

## Testing
- ✅ All model imports work correctly
- ✅ Pydantic validation still functional (tested with invalid inputs)
- ✅ Server loads successfully
- ✅ Tools continue to work (verified with test_slack_connection)
- ✅ Field descriptions preserved for MCP compatibility

## Related Issues
- Implements: #15 (Stage 2: Extract Pydantic Models)
- Part of: #20 (Umbrella issue for refactoring)
- Follows: #14 (Stage 1 - completed and merged)

## Next Steps
After this PR is merged:
- Stage 3: Extract Phase 1 Tools (Basic Operations) (#16)
- Continue with stages 4-7 for remaining tool groups
